### PR TITLE
Add automated inspektor gadget tests

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/aks-periscope/pkg/collector"
-	"github.com/Azure/aks-periscope/pkg/collector/inspektor-gadget"
+	inspektor_gadget "github.com/Azure/aks-periscope/pkg/collector/inspektor-gadget"
 	"github.com/Azure/aks-periscope/pkg/diagnoser"
 	"github.com/Azure/aks-periscope/pkg/exporter"
 	"github.com/Azure/aks-periscope/pkg/interfaces"
@@ -99,8 +99,8 @@ func run(osIdentifier utils.OSIdentifier, knownFilePaths *utils.KnownFilePaths, 
 		collector.NewSystemLogsCollector(osIdentifier, runtimeInfo),
 		collector.NewSystemPerfCollector(config, runtimeInfo),
 		collector.NewWindowsLogsCollector(osIdentifier, runtimeInfo, knownFilePaths, fileSystem, 10*time.Second, 20*time.Minute),
-		inspektor_gadget.NewInspektorGadgetDNSTraceCollector(config, runtimeInfo),
-		inspektor_gadget.NewInspektorGadgetTCPTraceCollector(config, runtimeInfo),
+		inspektor_gadget.NewInspektorGadgetDNSTraceCollector(osIdentifier, config, runtimeInfo, 2*time.Minute),
+		inspektor_gadget.NewInspektorGadgetTCPTraceCollector(osIdentifier, config, runtimeInfo, 2*time.Minute),
 	}
 
 	collectorGrp := new(sync.WaitGroup)

--- a/pkg/collector/inspektor-gadget/inspecktor_trace_collector.go
+++ b/pkg/collector/inspektor-gadget/inspecktor_trace_collector.go
@@ -5,15 +5,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Azure/aks-periscope/pkg/interfaces"
 	"github.com/Azure/aks-periscope/pkg/utils"
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -27,22 +25,19 @@ const (
 	GadgetOperation = "gadget.kinvolk.io/operation"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // InspektorGadgetTraceCollector defines a InspektorGadget Trace Collector that are common to trace gadgets
 type InspektorGadgetTraceCollector struct {
-	data          map[string]string
-	kubeconfig    *restclient.Config
-	commandRunner *utils.KubeCommandRunner
-	runtimeInfo   *utils.RuntimeInfo
+	data             map[string]string
+	osIdentifier     utils.OSIdentifier
+	kubeconfig       *restclient.Config
+	commandRunner    *utils.KubeCommandRunner
+	runtimeInfo      *utils.RuntimeInfo
+	collectingPeriod time.Duration
 }
 
-func (collector *InspektorGadgetTraceCollector) runTraceCommandOnPod(traceGadgetName string,
+func (collector *InspektorGadgetTraceCollector) runTraceCommandOnPod(gadgetName string,
 	gadgetClient runtimeclient.Client,
-	trace *gadgetv1alpha1.Trace,
-	collectingPeriod time.Duration) error {
+	trace *gadgetv1alpha1.Trace) error {
 
 	// Creates the clientset
 	clientset, err := kubernetes.NewForConfig(collector.kubeconfig)
@@ -50,65 +45,63 @@ func (collector *InspektorGadgetTraceCollector) runTraceCommandOnPod(traceGadget
 		return fmt.Errorf("getting access to K8S failed: %w", err)
 	}
 
-	gadgetPods, err := clientset.CoreV1().Pods("gadget").List(context.TODO(), metav1.ListOptions{})
+	podName, err := collector.getGadgetPodName(clientset)
 	if err != nil {
-		return fmt.Errorf("could not list gadget pods: %w", err)
+		return fmt.Errorf("failed to get gadget pod name: %w", err)
 	}
-	var command = []string{"./bin/gadgettracermanager", "-call", "receive-stream", "-tracerid", fmt.Sprintf("trace_gadget_%s", traceGadgetName)}
 
-	collectorGrp := new(sync.WaitGroup)
+	traceName := collector.getTraceName(gadgetName)
+	command := []string{"./bin/gadgettracermanager", "-call", "receive-stream", "-tracerid", fmt.Sprintf("trace_gadget_%s", traceName)}
 
-	for _, pod := range gadgetPods.Items {
+	collectChan := make(chan error)
+	go func() {
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		streamOptions := remotecommand.StreamOptions{
+			Stdout: stdout,
+			Stderr: stderr,
+		}
 
-		collectorGrp.Add(1)
-		go func(podName string) {
-			defer collectorGrp.Done()
+		request := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(podName).
+			Namespace("gadget").
+			SubResource("exec").
+			VersionedParams(&v1.PodExecOptions{
+				Stdin:   false,
+				Stdout:  true,
+				Stderr:  true,
+				TTY:     false,
+				Command: command,
+			}, scheme.ParameterCodec)
 
-			stdout := new(bytes.Buffer)
-			stderr := new(bytes.Buffer)
-			streamOptions := remotecommand.StreamOptions{
-				Stdout: stdout,
-				Stderr: stderr,
-			}
+		log.Printf("\tPost request to trace stream : %s ", request.URL())
+		exec, err := remotecommand.NewSPDYExecutor(collector.kubeconfig, "POST", request.URL())
+		if err != nil {
+			collectChan <- fmt.Errorf("error creating SPDYExecutor for pod exec %q: %w", podName, err)
+			return
+		}
 
-			request := clientset.CoreV1().RESTClient().Post().
-				Resource("pods").
-				Name(podName).
-				Namespace("gadget").
-				SubResource("exec").
-				VersionedParams(&v1.PodExecOptions{
-					Stdin:   false,
-					Stdout:  true,
-					Stderr:  true,
-					TTY:     false,
-					Command: command,
-				}, scheme.ParameterCodec)
+		log.Printf("\tCollecting trace stream %s from pod %s", traceName, podName)
+		err = exec.Stream(streamOptions)
+		if err != nil {
+			collectChan <- fmt.Errorf("error executing command %q on %s: %w\nOutput:\n%s", command, podName, err, stderr.String())
+			return
+		}
 
-			log.Printf("\tPost request to trace stream : %s ", request.URL())
-			exec, err := remotecommand.NewSPDYExecutor(collector.kubeconfig, "POST", request.URL())
+		log.Printf("\tCollected trace stream %s from pod %s", traceName, podName)
+		result := strings.TrimSpace(stdout.String()) + "\n" + strings.TrimSpace(stderr.String())
 
-			if err != nil {
-				log.Printf("\tError creating SPDYExecutor for pod exec %q: %v", podName, err)
-				return
-			}
-
-			err = exec.Stream(streamOptions)
-			if err != nil {
-				log.Printf("\tObtain trace stream erred: %s, %v. Try a different pod ", podName, err)
-				return
-			}
-
-			log.Printf("\tCollecting trace stream %s from pod %s", traceGadgetName, podName)
-			result := strings.TrimSpace(stdout.String()) + "\n" + strings.TrimSpace(stderr.String())
-			result = strings.TrimSpace(result)
-			collector.data[fmt.Sprintf("%s-%s", traceGadgetName, podName)] = result
-			log.Printf("\tCollected trace stream %s from pod %s", traceGadgetName, podName)
-		}(pod.Name)
-	}
+		// Prefix the data key with 'gadget' to distinguish it from other collectors (e.g. the 'dns' collector).
+		// We don't need the node, pod or trace name in the key, because results are output per-node, and there will
+		// only be one trace for each gadget on each node.
+		collector.data[fmt.Sprintf("gadget-%s", gadgetName)] = result
+		collectChan <- nil
+	}()
 
 	//TODO kill in a proper way by apply annotation
-	log.Printf("\twait for %v to stop collection", collectingPeriod)
-	time.Sleep(collectingPeriod)
+	log.Printf("\twait for %v to stop collection", collector.collectingPeriod)
+	time.Sleep(collector.collectingPeriod)
 
 	err = gadgetClient.Delete(context.TODO(), trace)
 	if err != nil {
@@ -116,21 +109,38 @@ func (collector *InspektorGadgetTraceCollector) runTraceCommandOnPod(traceGadget
 	}
 
 	// wait for the final result to be written
-	collectorGrp.Wait()
-
-	return nil
+	return <-collectChan
 }
 
-func (collector *InspektorGadgetTraceCollector) randomPodID() string {
-	output := make([]byte, 5)
-	allowedCharacters := "0123456789abcdefghijklmnopqrstuvwxyz"
-	for i := range output {
-		output[i] = allowedCharacters[rand.Int31n(int32(len(allowedCharacters)))]
+// getGadgetPodName gets the name of the 'gadget' pod that runs on the same node as this Periscope instance
+// (Inspektor Gadget runs as a DaemonSet, so we expect there to be exactly one of these).
+func (collector *InspektorGadgetTraceCollector) getGadgetPodName(clientset *kubernetes.Clientset) (string, error) {
+	gadgetPods, err := clientset.CoreV1().Pods("gadget").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("could not list gadget pods: %w", err)
 	}
-	return string(output)
+
+	for _, pod := range gadgetPods.Items {
+		if pod.Spec.NodeName == collector.runtimeInfo.HostNodeName {
+			return pod.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no gadget pod found on node %q", collector.runtimeInfo.HostNodeName)
+}
+
+func (collector *InspektorGadgetTraceCollector) getTraceName(gadgetName string) string {
+	// There should be at most one trace for each gadget running on each node, so the combination of
+	// gadget name and hostname should be sufficient to uniquely identify this trace.
+	return fmt.Sprintf("%s-%s", gadgetName, collector.runtimeInfo.HostNodeName)
 }
 
 func (collector *InspektorGadgetTraceCollector) CheckSupported() error {
+	// Inspektor Gadget relies on eBPF which is not (currently) available on Windows nodes.
+	if collector.osIdentifier != utils.Linux {
+		return fmt.Errorf("unsupported OS: %s", collector.osIdentifier)
+	}
+
 	crds, err := collector.commandRunner.GetCRDUnstructuredList()
 	if err != nil {
 		return fmt.Errorf("error listing CRDs in cluster")
@@ -148,7 +158,7 @@ func (collector *InspektorGadgetTraceCollector) GetData() map[string]interfaces.
 	return utils.ToDataValueMap(collector.data)
 }
 
-func (collector *InspektorGadgetTraceCollector) collect(gadgetName string, collectionPeriod time.Duration) error {
+func (collector *InspektorGadgetTraceCollector) collect(gadgetName string) error {
 
 	gadgetScheme := runtime.NewScheme()
 
@@ -166,14 +176,14 @@ func (collector *InspektorGadgetTraceCollector) collect(gadgetName string, colle
 
 	// Create a gadget.
 	//TODO gadget name should be enum
-	traceGadgetName := fmt.Sprintf("%s-%s", gadgetName, collector.randomPodID())
+	traceName := collector.getTraceName(gadgetName)
 	trace := &gadgetv1alpha1.Trace{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "gadget",
 			Annotations: map[string]string{
 				GadgetOperation: string(gadgetv1alpha1.OperationStart),
 			},
-			Name: traceGadgetName,
+			Name: traceName,
 		},
 		Spec: gadgetv1alpha1.TraceSpec{
 			Node:       collector.runtimeInfo.HostNodeName,
@@ -185,12 +195,12 @@ func (collector *InspektorGadgetTraceCollector) collect(gadgetName string, colle
 	err = gadgetClient.Create(context.TODO(), trace)
 
 	if err != nil {
-		return fmt.Errorf("could not create trace %s: %w", traceGadgetName, err)
+		return fmt.Errorf("could not create trace %s: %w", traceName, err)
 	}
 
 	//TODO watch the trace until it is started
 	//collect output
-	err = collector.runTraceCommandOnPod(traceGadgetName, gadgetClient, trace, collectionPeriod)
+	err = collector.runTraceCommandOnPod(gadgetName, gadgetClient, trace)
 	if err != nil {
 		log.Printf("\t could not run trace : %s ", err)
 		return err

--- a/pkg/collector/inspektor-gadget/inspecktor_trace_dns_collector.go
+++ b/pkg/collector/inspektor-gadget/inspecktor_trace_dns_collector.go
@@ -19,14 +19,16 @@ func (collector *InspektorGadgetDNSTraceCollector) CheckSupported() error {
 }
 
 // NewInspektorGadgetDNSTraceCollector is a constructor.
-func NewInspektorGadgetDNSTraceCollector(config *restclient.Config, runtimeInfo *utils.RuntimeInfo) *InspektorGadgetDNSTraceCollector {
+func NewInspektorGadgetDNSTraceCollector(osIdentifier utils.OSIdentifier, config *restclient.Config, runtimeInfo *utils.RuntimeInfo, collectingPeriod time.Duration) *InspektorGadgetDNSTraceCollector {
 
 	return &InspektorGadgetDNSTraceCollector{
 		tracerGadget: &InspektorGadgetTraceCollector{
-			data:          make(map[string]string),
-			kubeconfig:    config,
-			commandRunner: utils.NewKubeCommandRunner(config),
-			runtimeInfo:   runtimeInfo,
+			data:             make(map[string]string),
+			osIdentifier:     osIdentifier,
+			kubeconfig:       config,
+			commandRunner:    utils.NewKubeCommandRunner(config),
+			runtimeInfo:      runtimeInfo,
+			collectingPeriod: collectingPeriod,
 		},
 	}
 }
@@ -37,7 +39,7 @@ func (collector *InspektorGadgetDNSTraceCollector) GetName() string {
 
 // Collect implements the interface method
 func (collector *InspektorGadgetDNSTraceCollector) Collect() error {
-	return collector.tracerGadget.collect("dns", 2*time.Minute)
+	return collector.tracerGadget.collect("dns")
 }
 
 // GetData implements the interface method

--- a/pkg/collector/inspektor-gadget/inspecktor_trace_dns_collector_test.go
+++ b/pkg/collector/inspektor-gadget/inspecktor_trace_dns_collector_test.go
@@ -1,0 +1,128 @@
+package inspektor_gadget
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/Azure/aks-periscope/pkg/test"
+	"github.com/Azure/aks-periscope/pkg/utils"
+	"k8s.io/client-go/rest"
+)
+
+func TestInspektorGadgetDNSTraceCollectorGetName(t *testing.T) {
+	const expectedName = "inspektorgadget-dns"
+
+	c := NewInspektorGadgetDNSTraceCollector("", nil, nil, 0)
+	actualName := c.GetName()
+	if actualName != expectedName {
+		t.Errorf("unexpected name: expected %s, found %s", expectedName, actualName)
+	}
+}
+
+func TestInspektorGadgetDNSTraceCollectorCheckSupported(t *testing.T) {
+	fixture, _ := test.GetClusterFixture()
+
+	// TODO: test absence of "traces.gadget.kinvolk.io" CRD (maybe by injecting expected CRD name into collector)
+	tests := []struct {
+		osIdentifier utils.OSIdentifier
+		wantErr      bool
+	}{
+		{
+			osIdentifier: utils.Windows,
+			wantErr:      true,
+		},
+		{
+			osIdentifier: utils.Linux,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		c := NewInspektorGadgetDNSTraceCollector(tt.osIdentifier, fixture.PeriscopeAccess.ClientConfig, nil, 0)
+		err := c.CheckSupported()
+		if (err != nil) != tt.wantErr {
+			t.Errorf("CheckSupported() error = %v, wantErr %v", err, tt.wantErr)
+		}
+	}
+}
+
+func TestInspektorGadgetDNSTraceCollectorCollect(t *testing.T) {
+	fixture, _ := test.GetClusterFixture()
+
+	nodeNames, err := fixture.GetNodeNames()
+	if err != nil {
+		t.Fatalf("Error getting node names: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		config         *rest.Config
+		hostNodeName   string
+		setupResources []string
+		wantErr        bool
+		wantData       map[string]*regexp.Regexp
+	}{
+		{
+			name:           "bad kubeconfig",
+			config:         &rest.Config{Host: string([]byte{0})},
+			hostNodeName:   "",
+			setupResources: []string{},
+			wantErr:        true,
+			wantData:       nil,
+		},
+		{
+			name:           "valid config",
+			config:         fixture.PeriscopeAccess.ClientConfig,
+			hostNodeName:   nodeNames[0],
+			setupResources: []string{},
+			wantErr:        false,
+			wantData: map[string]*regexp.Regexp{
+				"gadget-dns": regexp.MustCompile(fmt.Sprintf(`^\s*{\s*"node":\s*"%s"`, nodeNames[0])),
+			},
+		},
+		{
+			name:         "egress denied",
+			config:       fixture.PeriscopeAccess.ClientConfig,
+			hostNodeName: nodeNames[0],
+			setupResources: []string{
+				"/resources/chaos/block-dns-nwp.yaml",
+			},
+			wantErr: false,
+			wantData: map[string]*regexp.Regexp{
+				"gadget-dns": regexp.MustCompile(fmt.Sprintf(`^\s*{\s*"node":\s*"%s"`, nodeNames[0])),
+			},
+		},
+	}
+
+	setupResources := func(command string, resources []string) {
+		for _, resourcePath := range resources {
+			installResourceCommand := fmt.Sprintf("kubectl %s -f %s", command, resourcePath)
+			_, err = fixture.CommandRunner.Run(installResourceCommand, fixture.AdminAccess.GetKubeConfigBinding())
+			if err != nil {
+				t.Fatalf("Error installing resource %s: %v", resourcePath, err)
+			}
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupResources("create", tt.setupResources)
+			defer setupResources("delete", tt.setupResources)
+
+			runtimeInfo := &utils.RuntimeInfo{
+				HostNodeName: tt.hostNodeName,
+			}
+
+			c := NewInspektorGadgetDNSTraceCollector(utils.Linux, tt.config, runtimeInfo, time.Second)
+			err := c.Collect()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			data := c.GetData()
+			test.CompareCollectorData(t, tt.wantData, data)
+		})
+	}
+}

--- a/pkg/collector/inspektor-gadget/inspecktor_trace_tcp_collector.go
+++ b/pkg/collector/inspektor-gadget/inspecktor_trace_tcp_collector.go
@@ -19,14 +19,16 @@ func (collector *InspektorGadgetTCPTraceCollector) CheckSupported() error {
 }
 
 // NewInspektorGadgetTCPTraceCollector is a constructor.
-func NewInspektorGadgetTCPTraceCollector(config *restclient.Config, runtimeInfo *utils.RuntimeInfo) *InspektorGadgetTCPTraceCollector {
+func NewInspektorGadgetTCPTraceCollector(osIdentifier utils.OSIdentifier, config *restclient.Config, runtimeInfo *utils.RuntimeInfo, collectingPeriod time.Duration) *InspektorGadgetTCPTraceCollector {
 
 	return &InspektorGadgetTCPTraceCollector{
 		tracerGadget: &InspektorGadgetTraceCollector{
-			data:          make(map[string]string),
-			kubeconfig:    config,
-			commandRunner: utils.NewKubeCommandRunner(config),
-			runtimeInfo:   runtimeInfo,
+			data:             make(map[string]string),
+			osIdentifier:     osIdentifier,
+			kubeconfig:       config,
+			commandRunner:    utils.NewKubeCommandRunner(config),
+			runtimeInfo:      runtimeInfo,
+			collectingPeriod: collectingPeriod,
 		},
 	}
 }
@@ -37,7 +39,7 @@ func (collector *InspektorGadgetTCPTraceCollector) GetName() string {
 
 // Collect implements the interface method
 func (collector *InspektorGadgetTCPTraceCollector) Collect() error {
-	return collector.tracerGadget.collect("tcptracer", 2*time.Minute)
+	return collector.tracerGadget.collect("tcptracer")
 }
 
 // GetData implements the interface method

--- a/pkg/collector/inspektor-gadget/shared_test.go
+++ b/pkg/collector/inspektor-gadget/shared_test.go
@@ -1,4 +1,4 @@
-package collector
+package inspektor_gadget
 
 import (
 	"testing"

--- a/pkg/collector/kubeobjects_collector_test.go
+++ b/pkg/collector/kubeobjects_collector_test.go
@@ -68,20 +68,6 @@ func getDefaultKubeObjectResults(fixture *test.ClusterFixture) (map[string]*rege
 	return results, nil
 }
 
-func getNodeNames(fixture *test.ClusterFixture) ([]string, error) {
-	nodeList, err := fixture.AdminAccess.Clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error listing nodes: %w", err)
-	}
-
-	nodeNames := make([]string, len(nodeList.Items))
-	for i, node := range nodeList.Items {
-		nodeNames[i] = node.Name
-	}
-
-	return nodeNames, nil
-}
-
 func getNodeResults(nodeNames []string) map[string]*regexp.Regexp {
 	results := map[string]*regexp.Regexp{}
 	for _, nodeName := range nodeNames {
@@ -111,7 +97,7 @@ func TestKubeObjectsCollectorCollect(t *testing.T) {
 		t.Fatalf("Error determining expected results for default configuration: %v", err)
 	}
 
-	nodeNames, err := getNodeNames(fixture)
+	nodeNames, err := fixture.GetNodeNames()
 	if err != nil {
 		t.Fatalf("Error getting node names: %v", err)
 	}
@@ -228,7 +214,7 @@ func TestKubeObjectsCollectorCollect(t *testing.T) {
 
 			data := c.GetData()
 
-			compareCollectorData(t, tt.want, data)
+			test.CompareCollectorData(t, tt.want, data)
 		})
 	}
 }

--- a/pkg/collector/osm_collector_test.go
+++ b/pkg/collector/osm_collector_test.go
@@ -109,7 +109,7 @@ func TestOsmCollectorCollect(t *testing.T) {
 			}
 			data := c.GetData()
 
-			compareCollectorData(t, tt.want, data)
+			test.CompareCollectorData(t, tt.want, data)
 		})
 	}
 }

--- a/pkg/collector/smi_collector_test.go
+++ b/pkg/collector/smi_collector_test.go
@@ -85,7 +85,7 @@ func TestSmiCollectorCollect(t *testing.T) {
 			}
 			data := c.GetData()
 
-			compareCollectorData(t, tt.want, data)
+			test.CompareCollectorData(t, tt.want, data)
 		})
 	}
 }

--- a/pkg/test/clusterFixtureRunner.go
+++ b/pkg/test/clusterFixtureRunner.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Azure/aks-periscope/pkg/interfaces"
+	"github.com/Azure/aks-periscope/pkg/utils"
+)
+
+// To be called by TestMain, to run all the tests within a package.
+func RunPackageTests(m *testing.M) {
+	fixture, err := GetClusterFixture()
+	if err != nil {
+		// Initialization failed, so clean up and exit before even running tests.
+		fixture.Cleanup()
+		log.Fatalf("Error initializing tests: %v", err)
+	}
+	code := runTests(m, fixture)
+	os.Exit(code)
+}
+
+func runTests(m *testing.M, fixture *ClusterFixture) int {
+	// Always clean up after running all the tests. This is not strictly necessary,
+	// but helps ensure a clean test cluster for subsequent local test runs.
+	defer fixture.Cleanup()
+
+	// Run all the tests in the package.
+	code := m.Run()
+	if code != 0 {
+		// Output some informtation that may help diagnose test failures.
+		fixture.PrintDiagnostics()
+	}
+
+	// Check our tests haven't resulted in any unexpected Docker image usage
+	err := fixture.CheckDockerImages()
+	if err != nil {
+		// Fail the test run (even if the actual tests passed) to avoid merging code that
+		// pulls images during tests.
+		log.Printf("Failing due to unexpected Docker image usage (see test.dockerImageManager): %v", err)
+		code = 1
+	}
+
+	return code
+}
+
+func TestDataValue(t *testing.T, dataValue interfaces.DataValue, test func(string)) {
+	value, err := utils.GetContent(func() (io.ReadCloser, error) { return dataValue.GetReader() })
+	if err != nil {
+		t.Errorf("error reading value: %v", err)
+	}
+	test(value)
+}
+
+func CompareCollectorData(t *testing.T, expectedData map[string]*regexp.Regexp, actualData map[string]interfaces.DataValue) {
+	missingDataKeys := []string{}
+	for key, regexp := range expectedData {
+		dataValue, ok := actualData[key]
+		if ok {
+			TestDataValue(t, dataValue, func(value string) {
+				if !regexp.MatchString(value) {
+					t.Errorf("unexpected value for %s\n\texpected: %s\n\tfound: %s", key, regexp.String(), value)
+				}
+			})
+		} else {
+			missingDataKeys = append(missingDataKeys, key)
+		}
+	}
+	if len(missingDataKeys) > 0 {
+		t.Errorf("missing keys in actual data:\n%s", strings.Join(missingDataKeys, "\n"))
+	}
+
+	unexpectedDataKeys := []string{}
+	for key := range actualData {
+		if _, ok := expectedData[key]; !ok {
+			unexpectedDataKeys = append(unexpectedDataKeys, key)
+		}
+	}
+	if len(unexpectedDataKeys) > 0 {
+		t.Errorf("unexpected keys in actual data:\n%s", strings.Join(unexpectedDataKeys, "\n"))
+	}
+}

--- a/pkg/test/clusterResourceManagement.go
+++ b/pkg/test/clusterResourceManagement.go
@@ -143,7 +143,18 @@ func deployOsmApplications(clientset *kubernetes.Clientset, commandRunner *Tools
 	}
 
 	command, binds = getDeployOsmAppsCommand(kubeConfigFile.Name(), knownNamespaces)
-	_, err = commandRunner.Run(command, binds...)
+	output, err = commandRunner.Run(command, binds...)
+	fmt.Printf("%s\n%s\n\n", command, output)
+	if err != nil {
+		return fmt.Errorf("error installing applications for OSM: %w", err)
+	}
+
+	return nil
+}
+
+func deployInspektorGadget(commandRunner *ToolsCommandRunner, kubeConfigFile *os.File) error {
+	command, binds := getDeployInspektorGadgetCommand(kubeConfigFile.Name())
+	output, err := commandRunner.Run(command, binds...)
 	fmt.Printf("%s\n%s\n\n", command, output)
 	if err != nil {
 		return fmt.Errorf("error installing applications for OSM: %w", err)

--- a/pkg/test/dockerImageManagement.go
+++ b/pkg/test/dockerImageManagement.go
@@ -37,6 +37,7 @@ var requiredImages = []string{
 	fmt.Sprintf("docker.io/openservicemesh/osm-healthcheck:v%s", osmVersion),
 	fmt.Sprintf("docker.io/openservicemesh/osm-injector:v%s", osmVersion),
 	fmt.Sprintf("docker.io/openservicemesh/osm-preinstall:v%s", osmVersion),
+	fmt.Sprintf("ghcr.io/inspektor-gadget/inspektor-gadget:v%s", gadgetVersion),
 	"k8s.gcr.io/build-image/debian-base:buster-v1.7.2",
 	"k8s.gcr.io/coredns/coredns:v1.8.6",
 	"k8s.gcr.io/etcd:3.5.1-0",
@@ -112,6 +113,7 @@ func pullDockerImages(client *dockerclient.Client, imagesToPull []string) error 
 			pullOutput, err := client.ImagePull(context.Background(), image, dockertypes.ImagePullOptions{})
 			if err != nil {
 				pullErrorsChan <- fmt.Errorf("error pulling image %s: %w", image, err)
+				return
 			}
 			defer pullOutput.Close()
 			_, err = io.Copy(os.Stdout, pullOutput)

--- a/pkg/test/resources/Dockerfile
+++ b/pkg/test/resources/Dockerfile
@@ -1,19 +1,22 @@
 FROM docker:20.10.14-alpine3.15
 
 ARG OSM_VERSION
+ARG GADGET_VERSION
 
 # Add binaries/archives
 RUN apk add gettext && \
     wget -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-linux-amd64 && \
     wget -O /helm.tar.gz https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz && \
     wget -O /usr/local/bin/kubectl https://dl.k8s.io/release/v1.23.5/bin/linux/amd64/kubectl && \
-    wget -O /osm.tar.gz https://github.com/openservicemesh/osm/releases/download/v$OSM_VERSION/osm-v$OSM_VERSION-linux-amd64.tar.gz
+    wget -O /osm.tar.gz https://github.com/openservicemesh/osm/releases/download/v$OSM_VERSION/osm-v$OSM_VERSION-linux-amd64.tar.gz && \
+    wget -O /kubectl-gadget.tar.gz https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v$GADGET_VERSION/kubectl-gadget-linux-amd64-v$GADGET_VERSION.tar.gz
 
 # Set file modes and extract
 RUN chmod 755 /usr/local/bin/kind && \
     chmod 755 /usr/local/bin/kubectl && \
     tar -zxvf /helm.tar.gz && mv /linux-amd64/helm /usr/local/bin/helm && \
-    tar -zxvf /osm.tar.gz && mv /linux-amd64/osm /usr/local/bin/osm
+    tar -zxvf /osm.tar.gz && mv /linux-amd64/osm /usr/local/bin/osm && \
+    tar -zxvf /kubectl-gadget.tar.gz && mv /kubectl-gadget /usr/local/bin/kubectl-gadget
 
 # Copy resources
 ADD tools-resources /resources

--- a/pkg/test/resources/tools-resources/chaos/block-dns-nwp.yaml
+++ b/pkg/test/resources/tools-resources/chaos/block-dns-nwp.yaml
@@ -1,11 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: deny-all-traffic
-  namespace: demo
+  name: deny-all-egress
+  namespace: gadget
 spec:
   podSelector:
-    matchLabels:
-      app: dns
+    matchLabels: {}
   policyTypes:
     - Egress

--- a/pkg/test/toolsImageBuilder.go
+++ b/pkg/test/toolsImageBuilder.go
@@ -45,14 +45,17 @@ func (builder *ToolsImageBuilder) Build() error {
 
 	dockerFileTarReader := bytes.NewReader(archiveContent)
 
-	osmVersionVar := osmVersion // need a variable here, because we can't get a pointer to a const string
+	// need variables here, because we can't get a pointer to a const string
+	osmVersionVar := osmVersion
+	gadgetVersionVar := gadgetVersion
 	buildOptions := types.ImageBuildOptions{
 		Context:    dockerFileTarReader,
 		Dockerfile: "Dockerfile",
 		Remove:     true,
 		Tags:       []string{ToolsImageName},
 		BuildArgs: map[string]*string{
-			"OSM_VERSION": &osmVersionVar,
+			"OSM_VERSION":    &osmVersionVar,
+			"GADGET_VERSION": &gadgetVersionVar,
 		},
 	}
 

--- a/pkg/test/toolsImageCommands.go
+++ b/pkg/test/toolsImageCommands.go
@@ -110,6 +110,15 @@ func getDeployOsmAppsCommand(hostKubeconfigPath string, knownNamespaces *KnownNa
 	return strings.Join(commands, " && "), []string{getKubeConfigBinding(hostKubeconfigPath)}
 }
 
+func getDeployInspektorGadgetCommand(hostKubeconfigPath string) (string, []string) {
+	commands := []string{
+		"kubectl gadget undeploy",
+		fmt.Sprintf("kubectl gadget deploy --image ghcr.io/inspektor-gadget/inspektor-gadget:v%s --image-pull-policy Never", gadgetVersion),
+	}
+
+	return strings.Join(commands, " && "), []string{getKubeConfigBinding(hostKubeconfigPath)}
+}
+
 func getTestDiagnosticsCommand(hostKubeconfigPath string) (string, []string) {
 	commands := []string{
 		"printf '\nDESCRIBE NODES\n'",


### PR DESCRIPTION
Feel free to take what you wish from this...

Some changes wouldn't be necessary if the IG collectors were in the `collector` package. Should we keep it as a separate package?

Also, if we proceed with the idea of calling the `TracerCollection` code directly rather than creating a DaemonSet on the cluster, the code for deploying the `NetworkPolicy` resource would become redundant (because the automated tests don't actually execute on a cluster). But a fair amount of the test setup code would still be usable, I think.